### PR TITLE
Collect env params, connect to client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -6,13 +6,13 @@ import (
 )
 
 type RouteGuide struct {
-	client spec.RouteGuideClient
+	Client spec.RouteGuideClient
 }
 
 func (rg *RouteGuide) GetFeatures(ctx context.Context, points []spec.Point) ([]spec.Feature, error) {
 	var features = []spec.Feature{}
 	for _, point := range points {
-		feature, err := rg.client.GetFeature(ctx, &point)
+		feature, err := rg.Client.GetFeature(ctx, &point)
 		if err != nil {
 			return nil, err
 		}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -54,7 +54,7 @@ func TestGetFeatures(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			var routeGuide = RouteGuide{ client: fakeRouteGuideClient{ features: test.wantFeatures }}
+			var routeGuide = RouteGuide{ Client: fakeRouteGuideClient{ features: test.wantFeatures }}
 			ctx := context.Background()
 
 			gotFeatures, err := routeGuide.GetFeatures(ctx, test.inputPoints)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"google.golang.org/grpc"
+	"golang.org/x/net/context"
+	"github.com/heroku/silvia-runtime-university/client"
+	"github.com/heroku/silvia-runtime-university/spec"
+	"github.com/joeshaw/envdecode"
+)
+
+func main() {
+	flag.String("help", "", "Display usage")
+	flag.Parse()
+
+	type Config struct {
+		ServerUrl string `env:"SERVER_URL,default=grpc-server.herokuapp.com:80"`
+	}
+
+	var cfg Config
+	err := envdecode.Decode(&cfg)
+
+	conn, err := grpc.Dial(cfg.ServerUrl, grpc.WithInsecure())
+	if err != nil {
+		log.Fatalf("Error connecting: %v", err)
+	}
+	defer conn.Close()
+
+	c := client.RouteGuide{ Client: spec.NewRouteGuideClient(conn)}
+
+	var inputPoints = []spec.Point{
+		{ Latitude: 98349834, Longitude: 384738473 },
+		{ Latitude: 98349835, Longitude: 384738474 },
+		{ Latitude: 98349836, Longitude: 384738475 },
+	}
+
+	features, err := c.GetFeatures(context.Background(), inputPoints)
+	if err != nil {
+		log.Fatalf("Fetching features failed: %v", err)
+	}
+
+	log.Println("Features for the given points: ", features)
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	flag.String("help", "", "Display usage")
+	var serverUrlFlag = flag.String("server-url", "", "Url of server to connect to")
 	flag.Parse()
 
 	type Config struct {
@@ -20,8 +20,12 @@ func main() {
 
 	var cfg Config
 	err := envdecode.Decode(&cfg)
+	serverAddress := cfg.ServerUrl
+	if *serverUrlFlag != "" {
+		serverAddress = *serverUrlFlag
+	}
 
-	conn, err := grpc.Dial(cfg.ServerUrl, grpc.WithInsecure())
+	conn, err := grpc.Dial(serverAddress, grpc.WithInsecure())
 	if err != nil {
 		log.Fatalf("Error connecting: %v", err)
 	}
@@ -30,9 +34,9 @@ func main() {
 	c := client.RouteGuide{ Client: spec.NewRouteGuideClient(conn)}
 
 	var inputPoints = []spec.Point{
-		{ Latitude: 98349834, Longitude: 384738473 },
-		{ Latitude: 98349835, Longitude: 384738474 },
-		{ Latitude: 98349836, Longitude: 384738475 },
+		{ Latitude: 407838351, Longitude: -746143763 },
+		{ Latitude: 408122808, Longitude: -743999179 },
+		{ Latitude: 413628156, Longitude: -749015468 },
 	}
 
 	features, err := c.GetFeatures(context.Background(), inputPoints)

--- a/vendor/github.com/joeshaw/envdecode/LICENSE
+++ b/vendor/github.com/joeshaw/envdecode/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Joe Shaw
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/joeshaw/envdecode/README.md
+++ b/vendor/github.com/joeshaw/envdecode/README.md
@@ -1,0 +1,64 @@
+# envdecode #
+
+`envdecode` is a Go package for populating structs from environment
+variables.
+
+`envdecode` uses struct tags to map environment variables to fields,
+allowing you you use any names you want for environment variables.
+`envdecode` will recurse into nested structs, including pointers to
+nested structs, but it will not allocate new pointers to structs.
+
+## API ##
+
+Full API docs are available on
+[godoc.org](http://godoc.org/github.com/joeshaw/envdecode).
+
+Define a struct with `env` struct tags:
+
+```go
+type Config struct {
+    Hostname  string `env:"SERVER_HOSTNAME,default=localhost"`
+    Port      uint16 `env:"SERVER_PORT,default=8080"`
+
+    AWS struct {
+        ID        string   `env:"AWS_ACCESS_KEY_ID"`
+        Secret    string   `env:"AWS_SECRET_ACCESS_KEY,required"`
+        SnsTopics []string `env:"AWS_SNS_TOPICS"`
+    }
+
+    Timeout time.Duration `env:"TIMEOUT,default=1m,strict"`
+}
+```
+
+Fields *must be exported* (i.e. begin with a capital letter) in order
+for `envdecode` to work with them.  An error will be returned if a
+struct with no exported fields is decoded (including one that contains
+no `env` tags at all).
+
+Then call `envdecode.Decode`:
+
+```go
+var cfg Config
+err := envdecode.Decode(&cfg)
+```
+
+If you want all fields to act `strict`, you may use `envdecode.StrictDecode`:
+
+```go
+var cfg Config
+err := envdecode.StrictDecode(&cfg)
+```
+
+All parse errors will fail fast and return an error in this mode.
+
+## Supported types ##
+
+* Structs (and pointer to structs)
+* Slices of below defined types, separated by semicolon
+* `bool`
+* `float32`, `float64`
+* `int`, `int8`, `int16`, `int32`, `int64`
+* `uint`, `uint8`, `uint16`, `uint32`, `uint64`
+* `string`
+* `time.Duration`, using the [`time.ParseDuration()` format](http://golang.org/pkg/time/#ParseDuration)
+* `*url.URL`, using [`url.Parse()`](https://godoc.org/net/url#Parse)

--- a/vendor/github.com/joeshaw/envdecode/envdecode.go
+++ b/vendor/github.com/joeshaw/envdecode/envdecode.go
@@ -1,0 +1,413 @@
+// Package envdecode is a package for populating structs from environment
+// variables, using struct tags.
+package envdecode
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ErrInvalidTarget indicates that the target value passed to
+// Decode is invalid.  Target must be a non-nil pointer to a struct.
+var ErrInvalidTarget = errors.New("target must be non-nil pointer to struct that has at least one exported field with a valid env tag.")
+var ErrNoTargetFieldsAreSet = errors.New("none of the target fields were set from environment variables")
+
+// FailureFunc is called when an error is encountered during a MustDecode
+// operation. It prints the error and terminates the process.
+//
+// This variable can be assigned to another function of the user-programmer's
+// design, allowing for graceful recovery of the problem, such as loading
+// from a backup configuration file.
+var FailureFunc = func(err error) {
+	log.Fatalf("envdecode: an error was encountered while decoding: %v\n", err)
+}
+
+// Decoder is the interface implemented by an object that can decode an
+// environment variable string representation of itself.
+type Decoder interface {
+	Decode(string) error
+}
+
+// Decode environment variables into the provided target.  The target
+// must be a non-nil pointer to a struct.  Fields in the struct must
+// be exported, and tagged with an "env" struct tag with a value
+// containing the name of the environment variable.  An error is
+// returned if there are no exported members tagged.
+//
+// Default values may be provided by appending ",default=value" to the
+// struct tag.  Required values may be marked by appending ",required"
+// to the struct tag.  It is an error to provide both "default" and
+// "required". Strict values may be marked by appending ",strict" which
+// will return an error on Decode if there is an error while parsing.
+// If everything must be strict, consider using StrictDecode instead.
+//
+// All primitive types are supported, including bool, floating point,
+// signed and unsigned integers, and string.  Boolean and numeric
+// types are decoded using the standard strconv Parse functions for
+// those types.  Structs and pointers to structs are decoded
+// recursively.  time.Duration is supported via the
+// time.ParseDuration() function and *url.URL is supported via the
+// url.Parse() function. Slices are supported for all above mentioned
+// primitive types. Semicolon is used as delimiter in environment variables.
+func Decode(target interface{}) error {
+	nFields, err := decode(target, false)
+	if err != nil {
+		return err
+	}
+
+	// if we didn't do anything - the user probably did something
+	// wrong like leave all fields unexported.
+	if nFields == 0 {
+		return ErrNoTargetFieldsAreSet
+	}
+
+	return nil
+}
+
+// StrictDecode is similar to Decode except all fields will have an implicit
+// ",strict" on all fields.
+func StrictDecode(target interface{}) error {
+	nFields, err := decode(target, true)
+	if err != nil {
+		return err
+	}
+
+	// if we didn't do anything - the user probably did something
+	// wrong like leave all fields unexported.
+	if nFields == 0 {
+		return ErrInvalidTarget
+	}
+
+	return nil
+}
+
+func decode(target interface{}, strict bool) (int, error) {
+	s := reflect.ValueOf(target)
+	if s.Kind() != reflect.Ptr || s.IsNil() {
+		return 0, ErrInvalidTarget
+	}
+
+	s = s.Elem()
+	if s.Kind() != reflect.Struct {
+		return 0, ErrInvalidTarget
+	}
+
+	t := s.Type()
+	setFieldCount := 0
+	for i := 0; i < s.NumField(); i++ {
+		// Localize the umbrella `strict` value to the specific field.
+		strict := strict
+
+		f := s.Field(i)
+
+		switch f.Kind() {
+		case reflect.Ptr:
+			if f.Elem().Kind() != reflect.Struct {
+				break
+			}
+
+			f = f.Elem()
+			fallthrough
+
+		case reflect.Struct:
+			ss := f.Addr().Interface()
+			_, custom := ss.(Decoder)
+			if custom {
+				break
+			}
+
+			n, err := decode(ss, strict)
+			if err != nil {
+				return 0, err
+			}
+			setFieldCount += n
+		}
+
+		if !f.CanSet() {
+			continue
+		}
+
+		tag := t.Field(i).Tag.Get("env")
+		if tag == "" {
+			continue
+		}
+
+		parts := strings.Split(tag, ",")
+		env := os.Getenv(parts[0])
+
+		required := false
+		hasDefault := false
+		defaultValue := ""
+
+		for _, o := range parts[1:] {
+			if !required {
+				required = strings.HasPrefix(o, "required")
+			}
+			if strings.HasPrefix(o, "default=") {
+				hasDefault = true
+				defaultValue = o[8:]
+			}
+			if !strict {
+				strict = strings.HasPrefix(o, "strict")
+			}
+		}
+
+		if required && hasDefault {
+			panic(`envdecode: "default" and "required" may not be specified in the same annotation`)
+		}
+		if env == "" && required {
+			return 0, fmt.Errorf("the environment variable \"%s\" is missing", parts[0])
+		}
+		if env == "" {
+			env = defaultValue
+		}
+		if env == "" {
+			continue
+		}
+
+		setFieldCount++
+
+		decoder, custom := f.Addr().Interface().(Decoder)
+		if custom {
+			if err := decoder.Decode(env); err != nil {
+				return 0, err
+			}
+		} else if f.Kind() == reflect.Slice {
+			decodeSlice(&f, env)
+		} else {
+			if err := decodePrimitiveType(&f, env); err != nil && strict {
+				return 0, err
+			}
+		}
+	}
+
+	return setFieldCount, nil
+}
+
+func decodeSlice(f *reflect.Value, env string) {
+	parts := strings.Split(env, ";")
+
+	values := parts[:0]
+	for _, x := range parts {
+		if x != "" {
+			values = append(values, strings.TrimSpace(x))
+		}
+	}
+
+	valuesCount := len(values)
+	slice := reflect.MakeSlice(f.Type(), valuesCount, valuesCount)
+	if valuesCount > 0 {
+		for i := 0; i < valuesCount; i++ {
+			e := slice.Index(i)
+			decodePrimitiveType(&e, values[i])
+		}
+	}
+
+	f.Set(slice)
+}
+
+func decodePrimitiveType(f *reflect.Value, env string) error {
+	switch f.Kind() {
+	case reflect.Bool:
+		v, err := strconv.ParseBool(env)
+		if err != nil {
+			return err
+		}
+		f.SetBool(v)
+
+	case reflect.Float32, reflect.Float64:
+		bits := f.Type().Bits()
+		v, err := strconv.ParseFloat(env, bits)
+		if err != nil {
+			return err
+		}
+		f.SetFloat(v)
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if t := f.Type(); t.PkgPath() == "time" && t.Name() == "Duration" {
+			v, err := time.ParseDuration(env)
+			if err != nil {
+				return err
+			}
+			f.SetInt(int64(v))
+		} else {
+			bits := f.Type().Bits()
+			v, err := strconv.ParseInt(env, 0, bits)
+			if err != nil {
+				return err
+			}
+			f.SetInt(v)
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		bits := f.Type().Bits()
+		v, err := strconv.ParseUint(env, 0, bits)
+		if err != nil {
+			return err
+		}
+		f.SetUint(v)
+
+	case reflect.String:
+		f.SetString(env)
+
+	case reflect.Ptr:
+		if t := f.Type().Elem(); t.Kind() == reflect.Struct && t.PkgPath() == "net/url" && t.Name() == "URL" {
+			v, err := url.Parse(env)
+			if err != nil {
+				return err
+			}
+			f.Set(reflect.ValueOf(v))
+		}
+	}
+	return nil
+}
+
+// MustDecode calls Decode and terminates the process if any errors
+// are encountered.
+func MustDecode(target interface{}) {
+	err := Decode(target)
+	if err != nil {
+		FailureFunc(err)
+	}
+}
+
+// MustStrictDecode calls StrictDecode and terminates the process if any errors
+// are encountered.
+func MustStrictDecode(target interface{}) {
+	err := StrictDecode(target)
+	if err != nil {
+		FailureFunc(err)
+	}
+}
+
+//// Configuration info for Export
+
+type ConfigInfo struct {
+	Field        string
+	EnvVar       string
+	Value        string
+	DefaultValue string
+	HasDefault   bool
+	Required     bool
+	UsesEnv      bool
+}
+
+type ConfigInfoSlice []*ConfigInfo
+
+func (c ConfigInfoSlice) Less(i, j int) bool {
+	return c[i].EnvVar < c[j].EnvVar
+}
+func (c ConfigInfoSlice) Len() int {
+	return len(c)
+}
+func (c ConfigInfoSlice) Swap(i, j int) {
+	c[i], c[j] = c[j], c[i]
+}
+
+// Returns a list of final configuration metadata sorted by envvar name
+func Export(target interface{}) ([]*ConfigInfo, error) {
+	s := reflect.ValueOf(target)
+	if s.Kind() != reflect.Ptr || s.IsNil() {
+		return nil, ErrInvalidTarget
+	}
+
+	cfg := []*ConfigInfo{}
+
+	s = s.Elem()
+	if s.Kind() != reflect.Struct {
+		return nil, ErrInvalidTarget
+	}
+
+	t := s.Type()
+	for i := 0; i < s.NumField(); i++ {
+		f := s.Field(i)
+		fName := t.Field(i).Name
+
+		fElem := f
+		if f.Kind() == reflect.Ptr {
+			fElem = f.Elem()
+		}
+		if fElem.Kind() == reflect.Struct {
+			ss := fElem.Addr().Interface()
+			subCfg, err := Export(ss)
+			if err != ErrInvalidTarget {
+				f = fElem
+				for _, v := range subCfg {
+					v.Field = fmt.Sprintf("%s.%s", fName, v.Field)
+					cfg = append(cfg, v)
+				}
+			}
+		}
+
+		tag := t.Field(i).Tag.Get("env")
+		if tag == "" {
+			continue
+		}
+
+		parts := strings.Split(tag, ",")
+
+		ci := &ConfigInfo{
+			Field:   fName,
+			EnvVar:  parts[0],
+			UsesEnv: os.Getenv(parts[0]) != "",
+		}
+
+		for _, o := range parts[1:] {
+			if strings.HasPrefix(o, "default=") {
+				ci.HasDefault = true
+				ci.DefaultValue = o[8:]
+			} else if strings.HasPrefix(o, "required") {
+				ci.Required = true
+			}
+		}
+
+		if f.Kind() == reflect.Ptr && f.IsNil() {
+			ci.Value = ""
+		} else if stringer, ok := f.Interface().(fmt.Stringer); ok {
+			ci.Value = stringer.String()
+		} else {
+			switch f.Kind() {
+			case reflect.Bool:
+				ci.Value = strconv.FormatBool(f.Bool())
+
+			case reflect.Float32, reflect.Float64:
+				bits := f.Type().Bits()
+				ci.Value = strconv.FormatFloat(f.Float(), 'f', -1, bits)
+
+			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+				ci.Value = strconv.FormatInt(f.Int(), 10)
+
+			case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+				ci.Value = strconv.FormatUint(f.Uint(), 10)
+
+			case reflect.String:
+				ci.Value = f.String()
+
+			case reflect.Slice:
+				ci.Value = fmt.Sprintf("%v", f.Interface())
+
+			default:
+				// Unable to determine string format for value
+				return nil, ErrInvalidTarget
+			}
+		}
+
+		cfg = append(cfg, ci)
+	}
+
+	// No configuration tags found, assume invalid input
+	if len(cfg) == 0 {
+		return nil, ErrInvalidTarget
+	}
+
+	sort.Sort(ConfigInfoSlice(cfg))
+
+	return cfg, nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,5 +1,11 @@
 {
 	"comment": "",
+	"heroku": {
+		"goVersion": "go1.9",
+		"install": [
+			"./..."
+		]
+	},
 	"ignore": "test",
 	"package": [
 		{
@@ -33,10 +39,28 @@
 			"revisionTime": "2017-11-13T18:07:20Z"
 		},
 		{
+			"path": "github.com/heroku/silvia-runtime-university",
+			"revision": ""
+		},
+		{
+			"path": "github.com/heroku/silvia-runtime-university/client",
+			"revision": ""
+		},
+		{
+			"path": "github.com/heroku/silvia-runtime-university/spec",
+			"revision": ""
+		},
+		{
+			"checksumSHA1": "+ao5OeNsFj1ZJqsaS55I3oAMrcY=",
+			"path": "github.com/joeshaw/envdecode",
+			"revision": "6326cbed175e32cd5183be1cc1027e0823c91edb",
+			"revisionTime": "2016-06-25T03:51:10Z"
+		},
+		{
 			"checksumSHA1": "GtamqiJoL7PGHsN454AoffBFMa8=",
 			"path": "golang.org/x/net/context",
-			"revision": "434ec0c7fe3742c984919a691b2018a6e9694425",
-			"revisionTime": "2017-09-25T09:26:47Z"
+			"revision": "5ccada7d0a7ba9aeb5d3aca8d3501b4c2a509fec",
+			"revisionTime": "2018-01-12T01:53:59Z"
 		},
 		{
 			"checksumSHA1": "VLRrE1AnzGMZf5Eud41ysvU3HOA=",
@@ -237,9 +261,5 @@
 			"revisionTime": "2018-01-05T23:37:05Z"
 		}
 	],
-	"rootPath": "github.com/heroku/silvia-runtime-university",
-	"heroku": {
-        "install" : [ "./..." ],
-        "goVersion": "go1.9"
-         }
+	"rootPath": "github.com/heroku/silvia-runtime-university"
 }


### PR DESCRIPTION
This change addresses Step 5 of the [RuntimeU project](https://github.com/heroku/runtime-team/blob/master/process/new-hire-success/runtime-university/coding-project/README.md).

At this point I'm unsure whether the output I'm getting matches what's being asked, so I'm submitting this to get initial feedback.

Tasks covered:

- [x] add `flag` package to enable `-help` for script usage information
- [x] collect `SERVER_URL` from env using `envdecode`
- [x] instantiate client
- [x] call `GetFeatures` on client with a hard coded set of point data
- [x] log events to STDOUT
- [x] export `Client` field in RouteGuide struct so I can use it in package `main`