### PR TITLE
Add docker images for running tests

### DIFF
--- a/Dockerfile_baseimage
+++ b/Dockerfile_baseimage
@@ -1,0 +1,10 @@
+FROM ubuntu:xenial
+
+RUN \
+  apt-get -qq update \
+  && apt-get install -y software-properties-common \
+  && add-apt-repository ppa:gophers/archive \
+  && apt-get install -y golang-1.9-go \
+  && apt-get clean
+
+ENV PATH="/usr/lib/go-1.9/bin:${PATH}"

--- a/Dockerfile_project
+++ b/Dockerfile_project
@@ -1,0 +1,5 @@
+FROM readysetgo:latest
+
+ENV GOPATH /go
+
+ADD . $GOPATH/src/github.com/heroku/silvia-runtime-university

--- a/Dockerfile_project
+++ b/Dockerfile_project
@@ -3,3 +3,7 @@ FROM readysetgo:latest
 ENV GOPATH /go
 
 ADD . $GOPATH/src/github.com/heroku/silvia-runtime-university
+
+WORKDIR $GOPATH/src/github.com/heroku/silvia-runtime-university
+
+CMD [ "go", "test", "-v", "./client/..." ]


### PR DESCRIPTION
This change addresses [Part 5](https://github.com/heroku/runtime-team/blob/master/process/new-hire-success/runtime-university/containerization/05-project.md) of the Containerization section of RuntimeU.

Base image from `Dockerfile_baseimage` should be created first with the tagname `readysetgo`
The `Dockerfile_project` image builds on top of the base image to copy the project files.